### PR TITLE
커뮤니티버전에서 .idea/ 폴더 추적하지 않도록함.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,7 @@ ENV/
 env.bak/
 venv.bak/
 
+.idea/
 # Spyder project settings
 .spyderproject
 .spyproject


### PR DESCRIPTION
community 버전에서 .idea/ 폴더를 무시하거나 삭제해도 작업은 된다고 하는데,
혹시 몰라서 .idea/폴더는 그대로 놔뒀습니다.
대신, clone할 때마다 idea폴더로 인해 error 없이 작업할 수 있게 대신 gitignore 에 .idea/ 작성해놨습니다.

.gitignore 파일만 수정함!